### PR TITLE
Add kakfa cost

### DIFF
--- a/views/nais_billing_regional/cost_breakdown_aiven.sql
+++ b/views/nais_billing_regional/cost_breakdown_aiven.sql
@@ -19,7 +19,11 @@ SELECT dates.dato as dato,
         else
           sum(cast(cost as numeric) * cast(r.usdeur as numeric) / number_of_days)
         end as calculated_cost
-FROM `nais-io.aiven_cost_regional.cost_items` c
-right outer join dates on substring(string(dates.dato), 0, 7) = c.date
-inner join `aiven_cost_regional.currency_rates` r on string(dates.dato) = r.date
+FROM
+   (select date, environment, team, tenant, service, cost, number_of_days from `nais-io.aiven_cost_regional.cost_items` WHERE service != 'kafka'
+   union all
+   select date, environment, team, tenant, service, cost, number_of_days from `nais-io.aiven_cost_regional.kafka_cost`)
+ as c
+ right outer join dates on substring(string(dates.dato), 0, 7) = c.date
+ inner join `aiven_cost_regional.currency_rates` r on string(dates.dato) = r.date
 GROUP BY month, dato, team, environment, service, tenant

--- a/views/nais_billing_regional/cost_breakdown_aiven.sql
+++ b/views/nais_billing_regional/cost_breakdown_aiven.sql
@@ -13,11 +13,11 @@ SELECT dates.dato as dato,
        c.date as month,
        service as service_description,
        service as sku_id,
-       case 
+       case
         when extract(month from dates.dato) = extract(month from current_date()) and extract(year from dates.dato) = extract(year from current_date()) then
-          sum(cast(cast(cost as float64) * 1000000 as int64) * cast(cast(r.usdeur as float64) * 1000000 as int64) / extract(day from current_date())) / (1000000 * 1000000)
+          sum(cast(cost as numeric) * cast(r.usdeur as numeric) / extract(day from current_date()))
         else
-          sum(cast(cast(cost as float64) * 1000000 as int64) * cast(cast(r.usdeur as float64) * 1000000 as int64) / cast(number_of_days as float64)) / (1000000 * 1000000)
+          sum(cast(cost as numeric) * cast(r.usdeur as numeric) / number_of_days)
         end as calculated_cost
 FROM `nais-io.aiven_cost_regional.cost_items` c
 right outer join dates on substring(string(dates.dato), 0, 7) = c.date


### PR DESCRIPTION
We're adding kafka-costs per team and it should be in the overview.. I also noticed there was a bunch of fixped precision calculations, they are now using numeric, a perfectly fine way of having a number. hope you dont mind . 

Co-authored-by: Christian Chavez <christian.chavez@nav.no>